### PR TITLE
Add "Isn't Sourcify a block explorer?" FAQ entry

### DIFF
--- a/src/pages/LandingPage/FAQ.tsx
+++ b/src/pages/LandingPage/FAQ.tsx
@@ -122,6 +122,23 @@ export default function FAQ() {
       ),
     },
     {
+      q: "Isn't Sourcify a block explorer?",
+      a: (
+        <>
+          <p className="mb-2">No. Sourcify's focus is contract verification only.</p>
+          <p className="mb-2">
+            Block explorers like Etherscan or Blockscout let users view all activity on the chain (transactions,
+            blocks, accounts, and more), which requires significant infrastructure and indexing the chains,
+            particularly difficult for chains with low block times.
+          </p>
+          <p className="mb-2">
+            Sourcify is only concerned with deployed contracts and their source code. In fact, block explorers can use
+            Sourcify as their verification backend, which is what Blockscout does.
+          </p>
+        </>
+      ),
+    },
+    {
       q: "What is the Verifier Alliance?",
       a: (
         <>


### PR DESCRIPTION
## Summary
- Adds a new FAQ entry "Isn't Sourcify a block explorer?" to the landing page
- Explains that Sourcify focuses only on contract verification, not full chain indexing
- Mentions Etherscan and Blockscout as examples of block explorers, and notes that Blockscout uses Sourcify as its verification backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)