### PR TITLE
Show parquet export size and DB size on landing page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
         "@ethersproject/bytes": "5.8.0",
         "@ethersproject/hash": "5.8.0",
         "@ethersproject/keccak256": "5.8.0",
-        "@headlessui/react": "2.2.9",
-        "@openrouter/ai-sdk-provider": "2.5.0",
+        "@headlessui/react": "2.2.10",
+        "@openrouter/ai-sdk-provider": "2.5.1",
         "@testing-library/react": "16.3.2",
         "@testing-library/user-event": "13.5.0",
-        "ai": "6.0.149",
+        "ai": "6.0.159",
         "bytes": "3.1.2",
         "framer-motion": "11.18.2",
         "fuse.js": "6.6.2",
@@ -26,10 +26,10 @@
         "react-dom": "18.3.1",
         "react-dropzone": "11.7.1",
         "react-icons": "5.6.0",
-        "react-router-dom": "7.14.0",
+        "react-router-dom": "7.14.1",
         "react-select-search": "3.0.10",
         "react-syntax-highlighter": "15.6.6",
-        "react-tooltip": "5.30.0",
+        "react-tooltip": "5.30.1",
         "recharts": "2.15.4",
         "web-vitals": "2.1.4"
       },
@@ -40,8 +40,8 @@
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@types/react-syntax-highlighter": "13.5.2",
-        "autoprefixer": "10.4.27",
-        "postcss": "8.5.8",
+        "autoprefixer": "10.5.0",
+        "postcss": "8.5.9",
         "react-scripts": "5.0.1",
         "tailwindcss": "3.4.19"
       },
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.91",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.91.tgz",
-      "integrity": "sha512-J39Dh6Gyg6HjG3A7OFKnJMp3QyZ3Eex+XDiX8aFBdRwwZm3jGWaMhkCxQPH7yiQ9kRiErZwHXX/Oexx4SyGGGA==",
+      "version": "3.0.96",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.96.tgz",
+      "integrity": "sha512-BDiVEMUVHGpngReeigzLyJobG0TvzYbNGzdHI8JYBZHrjOX4aL6qwIls7z3p7V4TuXVWUCbG8TSWEe7ksX4Vhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
@@ -3141,9 +3141,9 @@
       "license": "MIT"
     },
     "node_modules/@headlessui/react": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.9.tgz",
-      "integrity": "sha512-Mb+Un58gwBn0/yWZfyrCh0TJyurtT+dETj7YHleylHk5od3dv2XqETPGWMyQ5/7sYN7oWdyM1u9MvC0OC8UmzQ==",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.10.tgz",
+      "integrity": "sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.26.16",
@@ -3736,9 +3736,9 @@
       }
     },
     "node_modules/@openrouter/ai-sdk-provider": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-2.5.0.tgz",
-      "integrity": "sha512-QHGMh0sWHuvDDIF48VN2GQhAi0CQwGEwDlDxd6Q3DU4peiTefNLtMYefRCbI5zCaZxRRXXQxfGgScULeSwj9DA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-2.5.1.tgz",
+      "integrity": "sha512-r1fJL1Cb3gQDa2MpWH/sfx1BsEW0uzlRriJM6eihaKqbtKDmZoBisF32VcVaQYassighX7NGCkF68EsrZA43uQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -5353,12 +5353,12 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.149",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.149.tgz",
-      "integrity": "sha512-3asRb/m3ZGH7H4+VTuTgj8eQYJZ9IJUmV0ljLslY92mQp6Zj+NVn4SmFj0TBr2Y/wFBWC3xgn++47tSGOXxdbw==",
+      "version": "6.0.159",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.159.tgz",
+      "integrity": "sha512-S18ozG7Dkm3Ud1tzOtAK5acczD4vygfml80RkpM9VWMFpvAFwAKSHaGYkATvPQHIE+VpD1tJY9zcTXLZ/zR5cw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.91",
+        "@ai-sdk/gateway": "3.0.96",
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.23",
         "@opentelemetry/api": "1.9.0"
@@ -5778,9 +5778,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.27",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
-      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
       "dev": true,
       "funding": [
         {
@@ -5798,8 +5798,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1",
-        "caniuse-lite": "^1.0.30001774",
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -6085,9 +6085,9 @@
       "dev": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.10.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
+      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6253,9 +6253,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -6273,11 +6273,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -6393,9 +6393,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001775",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001775.tgz",
-      "integrity": "sha512-s3Qv7Lht9zbVKE9XoTyRG6wVDCKdtOFIjBGg3+Yhn6JaytuNKPIjBMTMIY1AnOH3seL5mvF+x33oGAyK3hVt3A==",
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
       "dev": true,
       "funding": [
         {
@@ -7961,9 +7961,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.302",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
-      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "version": "1.5.336",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
+      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -12890,9 +12890,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
     },
@@ -13517,9 +13517,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
       "dev": true,
       "funding": [
         {
@@ -15275,9 +15275,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
-      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.1.tgz",
+      "integrity": "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -15297,12 +15297,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.0.tgz",
-      "integrity": "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.1.tgz",
+      "integrity": "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.14.0"
+        "react-router": "7.14.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -15445,9 +15445,9 @@
       }
     },
     "node_modules/react-tooltip": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.30.0.tgz",
-      "integrity": "sha512-Yn8PfbgQ/wmqnL7oBpz1QiDaLKrzZMdSUUdk7nVeGTwzbxCAJiJzR4VSYW+eIO42F1INt57sPUmpgKv0KwJKtg==",
+      "version": "5.30.1",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.30.1.tgz",
+      "integrity": "sha512-1lSPLQXuVooePxadUpmcwLgOsF1mIty7UZTJ9XnyfX4drOzStYs4JMXnazcDLguQr41W5OUZddOp9kfvArdpEQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
         "@ethersproject/hash": "5.8.0",
         "@ethersproject/keccak256": "5.8.0",
         "@headlessui/react": "2.2.9",
-        "@openrouter/ai-sdk-provider": "2.3.3",
+        "@openrouter/ai-sdk-provider": "2.5.0",
         "@testing-library/react": "16.3.2",
         "@testing-library/user-event": "13.5.0",
-        "ai": "6.0.141",
+        "ai": "6.0.149",
         "bytes": "3.1.2",
         "framer-motion": "11.18.2",
         "fuse.js": "6.6.2",
@@ -26,7 +26,7 @@
         "react-dom": "18.3.1",
         "react-dropzone": "11.7.1",
         "react-icons": "5.6.0",
-        "react-router-dom": "7.13.2",
+        "react-router-dom": "7.14.0",
         "react-select-search": "3.0.10",
         "react-syntax-highlighter": "15.6.6",
         "react-tooltip": "5.30.0",
@@ -36,7 +36,7 @@
       "devDependencies": {
         "@types/aos": "3.0.7",
         "@types/bytes": "3.1.5",
-        "@types/node": "20.19.37",
+        "@types/node": "20.19.39",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@types/react-syntax-highlighter": "13.5.2",
@@ -50,13 +50,13 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.83",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.83.tgz",
-      "integrity": "sha512-LvlWujbSdEkTBXBLFtF7GS6riXdHhH0O+DpDrCaNQvXeHmSF2jKsOg7JWXiCgygAHM5cWFAO3JYmZp83DjiuBQ==",
+      "version": "3.0.91",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.91.tgz",
+      "integrity": "sha512-J39Dh6Gyg6HjG3A7OFKnJMp3QyZ3Eex+XDiX8aFBdRwwZm3jGWaMhkCxQPH7yiQ9kRiErZwHXX/Oexx4SyGGGA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.21",
+        "@ai-sdk/provider-utils": "4.0.23",
         "@vercel/oidc": "3.1.0"
       },
       "engines": {
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.21",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.21.tgz",
-      "integrity": "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==",
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
@@ -3736,9 +3736,9 @@
       }
     },
     "node_modules/@openrouter/ai-sdk-provider": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-2.3.3.tgz",
-      "integrity": "sha512-4fVteGkVedc7fGoA9+qJs4tpYwALezMq14m2Sjub3KmyRlksCbK+WJf67NPdGem8+NZrV2tAN42A1NU3+SiV3w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-2.5.0.tgz",
+      "integrity": "sha512-QHGMh0sWHuvDDIF48VN2GQhAi0CQwGEwDlDxd6Q3DU4peiTefNLtMYefRCbI5zCaZxRRXXQxfGgScULeSwj9DA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -4658,9 +4658,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5353,14 +5353,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.141",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.141.tgz",
-      "integrity": "sha512-+GomGQWaId3xN0wcugUW/H7xMMaFkID2PiS7K/Wugj45G3efv0BXhQ3psRZoQVoRbOpdNoUqcK/KTB+FR4h6qg==",
+      "version": "6.0.149",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.149.tgz",
+      "integrity": "sha512-3asRb/m3ZGH7H4+VTuTgj8eQYJZ9IJUmV0ljLslY92mQp6Zj+NVn4SmFj0TBr2Y/wFBWC3xgn++47tSGOXxdbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.83",
+        "@ai-sdk/gateway": "3.0.91",
         "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.21",
+        "@ai-sdk/provider-utils": "4.0.23",
         "@opentelemetry/api": "1.9.0"
       },
       "engines": {
@@ -15275,9 +15275,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
-      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
+      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -15297,12 +15297,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.2.tgz",
-      "integrity": "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.0.tgz",
+      "integrity": "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.2"
+        "react-router": "7.14.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
     "react-dom": "18.3.1",
     "react-dropzone": "11.7.1",
     "react-icons": "5.6.0",
-    "react-router-dom": "7.13.2",
+    "react-router-dom": "7.14.0",
     "react-select-search": "3.0.10",
     "react-syntax-highlighter": "15.6.6",
     "react-tooltip": "5.30.0",
     "recharts": "2.15.4",
     "web-vitals": "2.1.4",
-    "@openrouter/ai-sdk-provider": "2.3.3",
-    "ai": "6.0.141"
+    "@openrouter/ai-sdk-provider": "2.5.0",
+    "ai": "6.0.149"
   },
   "optionalDependencies": {
     "fsevents": "2.3.3"
@@ -63,7 +63,7 @@
   "devDependencies": {
     "@types/aos": "3.0.7",
     "@types/bytes": "3.1.5",
-    "@types/node": "20.19.37",
+    "@types/node": "20.19.39",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@types/react-syntax-highlighter": "13.5.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@ethersproject/bytes": "5.8.0",
     "@ethersproject/hash": "5.8.0",
     "@ethersproject/keccak256": "5.8.0",
-    "@headlessui/react": "2.2.9",
+    "@headlessui/react": "2.2.10",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "13.5.0",
     "bytes": "3.1.2",
@@ -19,14 +19,14 @@
     "react-dom": "18.3.1",
     "react-dropzone": "11.7.1",
     "react-icons": "5.6.0",
-    "react-router-dom": "7.14.0",
+    "react-router-dom": "7.14.1",
     "react-select-search": "3.0.10",
     "react-syntax-highlighter": "15.6.6",
-    "react-tooltip": "5.30.0",
+    "react-tooltip": "5.30.1",
     "recharts": "2.15.4",
     "web-vitals": "2.1.4",
-    "@openrouter/ai-sdk-provider": "2.5.0",
-    "ai": "6.0.149"
+    "@openrouter/ai-sdk-provider": "2.5.1",
+    "ai": "6.0.159"
   },
   "optionalDependencies": {
     "fsevents": "2.3.3"
@@ -67,8 +67,8 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@types/react-syntax-highlighter": "13.5.2",
-    "autoprefixer": "10.4.27",
-    "postcss": "8.5.8",
+    "autoprefixer": "10.5.0",
+    "postcss": "8.5.9",
     "react-scripts": "5.0.1",
     "tailwindcss": "3.4.19"
   },

--- a/src/pages/LandingPage/VerifiedContracts.tsx
+++ b/src/pages/LandingPage/VerifiedContracts.tsx
@@ -80,7 +80,7 @@ const Chart = () => {
   }, []);
 
   useEffect(() => {
-    fetch("https://export.sourcify.dev/v2/stats.json")
+    fetch(`https://export.${process.env.REACT_APP_TAG === "staging" ? "staging." : ""}sourcify.dev/v2/stats.json`)
       .then((res) => res.json())
       .then((json) => setDatasetStats(json))
       .catch(() => console.error("error fetching dataset stats"));

--- a/src/pages/LandingPage/VerifiedContracts.tsx
+++ b/src/pages/LandingPage/VerifiedContracts.tsx
@@ -6,6 +6,8 @@ import ChainSelect from "../../components/ChainSelect";
 import { motion, useInView } from "framer-motion";
 import Button from "../../components/Button";
 import { FaDownload } from "react-icons/fa";
+import { FiInfo } from "react-icons/fi";
+import { Tooltip as ReactTooltip } from "react-tooltip";
 
 const NUMBER_OF_TOP_CHAINS = 10;
 
@@ -16,6 +18,36 @@ type statsType = {
   };
 };
 
+type TableParquetStats = { bytes: number; fileCount: number };
+type TableDbStats = { bytes: number };
+type DatasetStatsType = {
+  generatedAt: string;
+  schemaVersion: string;
+  parquet: {
+    totalBytes: number;
+    fileCount: number;
+    tables: Record<string, TableParquetStats>;
+  };
+  database: {
+    totalBytes: number;
+    tables: Record<string, TableDbStats>;
+  };
+};
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1e12) return (bytes / 1e12).toFixed(1) + " TB";
+  if (bytes >= 1e9) return (bytes / 1e9).toFixed(1) + " GB";
+  if (bytes >= 1e6) return (bytes / 1e6).toFixed(1) + " MB";
+  return (bytes / 1e3).toFixed(1) + " KB";
+}
+
+function timeAgo(isoDate: string): string {
+  const diff = Math.floor((Date.now() - new Date(isoDate).getTime()) / 1000);
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
 const Chart = () => {
   const { sourcifyChainMap, sourcifyChains } = useContext(Context);
   const [selectedChain, setSelectedChain] = useState<string>("1");
@@ -23,6 +55,8 @@ const Chart = () => {
   const sectionRef = useRef(null);
   const isSectionInView = useInView(sectionRef, { once: true });
   const [stats, setStats] = useState<statsType | undefined>(undefined);
+
+  const [datasetStats, setDatasetStats] = useState<DatasetStatsType | null>(null);
 
   // Window width to make the chart responsive. We'll change the font sizes and tick width based on this
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
@@ -43,6 +77,13 @@ const Chart = () => {
       .then((res) => res.json())
       .then((json) => setStats(json))
       .catch(() => console.error("error fetching stats"));
+  }, []);
+
+  useEffect(() => {
+    fetch("https://export.sourcify.dev/v2/stats.json")
+      .then((res) => res.json())
+      .then((json) => setDatasetStats(json))
+      .catch(() => console.error("error fetching dataset stats"));
   }, []);
 
   useEffect(() => {
@@ -131,6 +172,114 @@ const Chart = () => {
               📊 stats.sourcify.dev
             </a>
           </motion.div>
+
+          {datasetStats && (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={isSectionInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
+              transition={{ duration: 0.6, delay: 0.2 }}
+              className="flex flex-col sm:flex-row gap-8 mt-8 justify-center"
+            >
+              {/* Parquet export size */}
+              <div className="flex flex-col items-center">
+                <div className="flex items-center gap-1">
+                  <span className="text-3xl md:text-4xl font-bold text-ceruleanBlue-500">
+                    {formatBytes(datasetStats.parquet.totalBytes)}
+                  </span>
+                  <FiInfo
+                    className="text-ceruleanBlue-300 hover:text-ceruleanBlue-500 cursor-pointer text-lg"
+                    data-tooltip-id="parquet-size-tooltip"
+                  />
+                </div>
+                <span className="text-sm md:text-base text-gray-600 mt-1">parquet export size</span>
+                <span className="text-xs text-gray-400 mt-0.5">updated {timeAgo(datasetStats.generatedAt)}</span>
+              </div>
+
+              {/* Database size */}
+              <div className="flex flex-col items-center">
+                <div className="flex items-center gap-1">
+                  <span className="text-3xl md:text-4xl font-bold text-ceruleanBlue-500">
+                    {formatBytes(datasetStats.database.totalBytes)}
+                  </span>
+                  <FiInfo
+                    className="text-ceruleanBlue-300 hover:text-ceruleanBlue-500 cursor-pointer text-lg"
+                    data-tooltip-id="db-size-tooltip"
+                  />
+                </div>
+                <span className="text-sm md:text-base text-gray-600 mt-1">database size</span>
+              </div>
+
+              <ReactTooltip
+                id="parquet-size-tooltip"
+                clickable
+                className="max-w-xs z-50"
+                render={() => (
+                  <div className="text-sm">
+                    <p className="mb-2">
+                      We export our complete Postgres database daily into Apache Parquet format.
+                      Sizes shown are with parquet (zstd) compression.
+                    </p>
+                    <a
+                      href="https://docs.sourcify.dev/docs/repository/download-dataset/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-ceruleanBlue-300 underline"
+                    >
+                      Learn more →
+                    </a>
+                    <table className="mt-3 w-full text-xs border-collapse">
+                      <thead>
+                        <tr className="border-b border-gray-600">
+                          <th className="text-left pr-3 pb-1">Table</th>
+                          <th className="text-right pr-3 pb-1">Size</th>
+                          <th className="text-right pb-1">Files</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {Object.entries(datasetStats.parquet.tables).map(([table, data]) => (
+                          <tr key={table} className="border-b border-gray-700">
+                            <td className="pr-3 py-0.5 font-mono">{table}</td>
+                            <td className="text-right pr-3 py-0.5">{formatBytes(data.bytes)}</td>
+                            <td className="text-right py-0.5">{data.fileCount}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              />
+
+              <ReactTooltip
+                id="db-size-tooltip"
+                clickable
+                className="max-w-xs z-50"
+                render={() => (
+                  <div className="text-sm">
+                    <p className="mb-3">
+                      Live sizes of the Sourcify Postgres database on Google Cloud. Includes indexes and TOAST.
+                      The total also includes system catalogs, so it is slightly larger than the sum of the tables below.
+                    </p>
+                    <table className="w-full text-xs border-collapse">
+                      <thead>
+                        <tr className="border-b border-gray-600">
+                          <th className="text-left pr-3 pb-1">Table</th>
+                          <th className="text-right pb-1">Size</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {Object.entries(datasetStats.database.tables).map(([table, data]) => (
+                          <tr key={table} className="border-b border-gray-700">
+                            <td className="pr-3 py-0.5 font-mono">{table}</td>
+                            <td className="text-right py-0.5">{formatBytes(data.bytes)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              />
+            </motion.div>
+          )}
           <div className="flex flex-col items-center my-8">
             <Button type="">
               <a


### PR DESCRIPTION
## Summary

- Fetches `https://export.sourcify.dev/v2/stats.json` (published by the export job) and renders two new headline figures in the `#verified-contracts` section alongside the contract count:
  - **Parquet export size** — total compressed size of all parquet files
  - **Database size** — live Postgres DB size
- Each figure has an info icon (`FiInfo`) that opens a `react-tooltip` with a per-table breakdown:
  - Parquet tooltip: explains daily export + zstd compression, links to docs, shows Table / Size / Files table.
  - DB tooltip: explains live Postgres sizes including indexes/TOAST, shows Table / Size table.
- On fetch error the two figures are hidden gracefully — the existing contract count is unaffected.

> **Requires** verifier-alliance/parquet-export#17 to be merged and deployed first so that `v2/stats.json` is published.

## Test plan

- [ ] `npm start`, scroll to `#verified-contracts`, confirm both figures appear with correct values.
- [ ] Hover/click the info icons and verify tooltip content and per-table tables.
- [ ] Click the "Learn more →" link in the parquet tooltip; verify it opens the correct docs page.
- [ ] Throttle `export.sourcify.dev` to offline in devtools; confirm the two figures disappear without affecting the contract count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)