### PR TITLE
Replace HashRouter with BrowserRouter; redesign /address page with Sourcify v2 API

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 REACT_APP_SERVER_URL=http://localhost:5555
-REACT_APP_REPOSITORY_URL=http://localhost:5173
+REACT_APP_REPOSITORY_URL=http://repo.staging.sourcify.dev
 REACT_APP_VERIFY_URL=http://verify.staging.sourcify.dev
 REACT_APP_TAG=development
 REACT_APP_OPENROUTER_API_KEY=

--- a/public/index.html
+++ b/public/index.html
@@ -7,13 +7,13 @@
     <meta name="theme-color" content="#000000" />
     <script>
       // Migrate legacy hash-router URLs (#/...) to clean paths.
-      // #/lookup/<address> → /address/<address>; everything else: #/<rest> → /<rest>.
+      // /lookup[/<rest>] → /address[/<rest>]; everything else: #/<rest> → /<rest>.
       (function () {
         var hash = window.location.hash;
         if (hash.indexOf("#/") !== 0) return;
         var path = hash.slice(1);
-        var match = path.match(/^\/lookup\/(.+)$/);
-        if (match) path = "/address/" + match[1];
+        var match = path.match(/^\/lookup(\/.*)?$/);
+        if (match) path = "/address" + (match[1] || "");
         window.history.replaceState(null, "", path + window.location.search);
       })();
     </script>

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,18 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <script>
+      // Migrate legacy hash-router URLs (#/...) to clean paths.
+      // #/lookup/<address> → /address/<address>; everything else: #/<rest> → /<rest>.
+      (function () {
+        var hash = window.location.hash;
+        if (hash.indexOf("#/") !== 0) return;
+        var path = hash.slice(1);
+        var match = path.match(/^\/lookup\/(.+)$/);
+        if (match) path = "/address/" + match[1];
+        window.history.replaceState(null, "", path + window.location.search);
+      })();
+    </script>
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@sourcifyeth" />
     <meta name="og:title" content="sourcify.eth" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useParams } from "react-router-dom";
+import { Tooltip } from "react-tooltip";
 import { ContextProvider } from "./Context";
 import LandingPage from "./pages/LandingPage";
 import Lookup from "./pages/Lookup";
@@ -19,6 +20,7 @@ function App() {
 
   return (
     <div className="flex min-h-screen text-gray-800 bg-gray-50">
+      <Tooltip id="global-tooltip" delayHide={300} clickable style={{ zIndex: 9999 }} />
       <ContextProvider>
         <BrowserRouter>
           <Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import VerifyRedirect from "./pages/VerifyRedirect";
 
 const LegacyLookupRedirect = () => {
   const { address } = useParams();
-  return <Navigate to={`/address/${address}`} replace />;
+  return <Navigate to={address ? `/address/${address}` : "/address"} replace />;
 };
 
 function App() {
@@ -23,8 +23,9 @@ function App() {
         <BrowserRouter>
           <Routes>
             <Route path="/verifier" element={<VerifyRedirect />} />
-            <Route path="/lookup" element={<Lookup />} />
+            <Route path="/lookup" element={<LegacyLookupRedirect />} />
             <Route path="/lookup/:address" element={<LegacyLookupRedirect />} />
+            <Route path="/address" element={<Lookup />} />
             <Route path="/address/:address" element={<Lookup />} />
             <Route path="/dataset-playground" element={<LandingPage />} />
             <Route path="/" element={<LandingPage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ function App() {
 
   return (
     <div className="flex min-h-screen text-gray-800 bg-gray-50">
-      <Tooltip id="global-tooltip" delayHide={300} clickable style={{ zIndex: 9999 }} />
+      <Tooltip id="global-tooltip" delayHide={300} clickable style={{ zIndex: 9999, maxWidth: "16rem", fontSize: "0.75rem" }} />
       <ContextProvider>
         <BrowserRouter>
           <Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,14 @@
 import { useEffect } from "react";
-import { HashRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Navigate, Route, Routes, useParams } from "react-router-dom";
 import { ContextProvider } from "./Context";
 import LandingPage from "./pages/LandingPage";
 import Lookup from "./pages/Lookup";
 import VerifyRedirect from "./pages/VerifyRedirect";
+
+const LegacyLookupRedirect = () => {
+  const { address } = useParams();
+  return <Navigate to={`/address/${address}`} replace />;
+};
 
 function App() {
   useEffect(() => {
@@ -15,15 +20,16 @@ function App() {
   return (
     <div className="flex min-h-screen text-gray-800 bg-gray-50">
       <ContextProvider>
-        <HashRouter>
+        <BrowserRouter>
           <Routes>
             <Route path="/verifier" element={<VerifyRedirect />} />
             <Route path="/lookup" element={<Lookup />} />
-            <Route path="/lookup/:address" element={<Lookup />} />
+            <Route path="/lookup/:address" element={<LegacyLookupRedirect />} />
+            <Route path="/address/:address" element={<Lookup />} />
             <Route path="/dataset-playground" element={<LandingPage />} />
             <Route path="/" element={<LandingPage />} />
           </Routes>
-        </HashRouter>
+        </BrowserRouter>
       </ContextProvider>
     </div>
   );

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -74,7 +74,7 @@ const Header = ({ className }: { className?: string }) => {
             >
               Verify
             </a>
-            <Link className="link-underline mx-2 my-2 lg:mx-6 hover:text-ceruleanBlue-500" to="/lookup">
+            <Link className="link-underline mx-2 my-2 lg:mx-6 hover:text-ceruleanBlue-500" to="/address">
               Lookup
             </Link>
             <a

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from "react-tooltip";
 import { SiMatrix } from "react-icons/si";
 import { RiTwitterXFill } from "react-icons/ri";
 import logoText from "../../assets/logo-rounded.svg";
-import { DOCS_URL, PLAYGROUND_URL } from "../../constants";
+import { DOCS_URL, PLAYGROUND_URL, REPOSITORY_URL } from "../../constants";
 
 const Header = ({ className }: { className?: string }) => {
   const [showNav, setShowNav] = useState(false);
@@ -79,7 +79,7 @@ const Header = ({ className }: { className?: string }) => {
             </Link>
             <a
               className="link-underline mx-2 my-2 lg:mx-6 hover:text-ceruleanBlue-500"
-              href="https://repo.sourcify.dev"
+              href={REPOSITORY_URL}
             >
               Contract Repo
             </a>

--- a/src/components/MatchBadge/index.tsx
+++ b/src/components/MatchBadge/index.tsx
@@ -1,0 +1,43 @@
+import { IoCheckmarkDoneCircle, IoCheckmarkCircle } from "react-icons/io5";
+
+interface MatchBadgeProps {
+  match: "match" | "exact_match" | null;
+  className?: string;
+  small?: boolean;
+}
+
+const MatchBadge = ({ match, className = "", small = false }: MatchBadgeProps) => {
+  const sizeClasses = small ? "px-2 py-1 text-xs md:text-sm whitespace-nowrap" : "px-2 py-1 md:px-3 md:py-1 text-sm md:text-base whitespace-nowrap";
+  const iconSize = small ? "text-xl" : "text-2xl md:text-3xl";
+
+  if (!match) {
+    return (
+      <span
+        className={`inline-flex items-center ${sizeClasses} rounded-md font-semibold border bg-gray-100 text-gray-600 border-gray-200 flex-shrink-0 ${className}`}
+      >
+        <span className={`mr-1 ${iconSize}`}>-</span> No Match
+      </span>
+    );
+  }
+
+  const isExactMatch = match === "exact_match";
+  const label = isExactMatch ? "Exact Match" : "Match";
+  const tooltipContent = isExactMatch
+    ? "Exact match: The onchain and compiled bytecode match exactly, including the metadata hashes."
+    : "Match: The onchain and compiled bytecode match, but metadata hashes differ or don't exist.";
+
+  return (
+    <span
+      className={`inline-flex items-center ${sizeClasses} rounded-md font-semibold border bg-green-100 text-green-800 border-green-200 cursor-help flex-shrink-0 ${className}`}
+      data-tooltip-id="global-tooltip"
+      data-tooltip-content={tooltipContent}
+    >
+      <span className={`mr-1 ${iconSize}`}>
+        {isExactMatch ? <IoCheckmarkDoneCircle /> : <IoCheckmarkCircle />}
+      </span>
+      {label}
+    </span>
+  );
+};
+
+export default MatchBadge;

--- a/src/components/PageLayout/index.tsx
+++ b/src/components/PageLayout/index.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+
+interface PageLayoutProps {
+  children: ReactNode;
+  maxWidth?: "max-w-4xl" | "max-w-6xl";
+  title?: string;
+  subtitle?: string;
+}
+
+const PageLayout = ({ children, maxWidth = "max-w-4xl", title, subtitle }: PageLayoutProps) => {
+  return (
+    <div className="flex-1 bg-ceruleanBlue-50 pt-6 pb-12">
+      <div className={`${maxWidth} mx-auto px-4 md:px-8 mt-6 md:mt-12`}>
+        <div className="relative mt-4">
+          <div className="absolute w-full h-full bg-ceruleanBlue-500 rounded-lg -top-1" />
+          <div className="relative bg-white shadow-lg rounded-lg">
+            {(title || subtitle) && (
+              <div className="text-center p-4 md:p-8 border-b border-gray-200">
+                {title && (
+                  <h1 className="text-2xl md:text-3xl font-semibold text-gray-900 tracking-tight">{title}</h1>
+                )}
+                {subtitle && (
+                  <p className="max-w-2xl mx-auto text-sm md:text-base text-gray-600 mt-1">{subtitle}</p>
+                )}
+              </div>
+            )}
+            <div className="p-4 md:p-8">{children}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PageLayout;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 export const REPOSITORY_URL = process.env.REACT_APP_REPOSITORY_URL;
+export const VERIFY_URL = process.env.REACT_APP_VERIFY_URL;
 export const SERVER_URL = process.env.REACT_APP_SERVER_URL;
 export const BIGQUERY_API_URL = process.env.REACT_APP_BIGQUERY_API_URL;
 export const BIGQUERY_DATASET_NAME =

--- a/src/pages/Lookup/Field.tsx
+++ b/src/pages/Lookup/Field.tsx
@@ -12,7 +12,8 @@ const EXAMPLE_ADDRESS = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
 const Field = ({ loading, handleRequest }: FieldProp) => {
   const [value, setValue] = useState<string>("");
   const [touched, setTouched] = useState<boolean>(false);
-  const invalid = touched && value.length > 0 && !isAddress(value);
+  // Show error once they've typed enough to be attempting an address, or after blur
+  const invalid = value.length > 0 && !isAddress(value) && (touched || value.length >= 42);
 
   const handleChange = (input: string) => {
     setValue(input);

--- a/src/pages/Lookup/Field.tsx
+++ b/src/pages/Lookup/Field.tsx
@@ -1,76 +1,68 @@
 import { isAddress, getAddress } from "@ethersproject/address";
-import { ChangeEventHandler, FormEventHandler, useState } from "react";
-import Input from "../../components/Input";
+import { FormEventHandler, useState } from "react";
 import LoadingOverlay from "../../components/LoadingOverlay";
-import Toast from "../../components/Toast";
 
 type FieldProp = {
   loading: boolean;
   handleRequest: (address: string) => void;
 };
 
-const Field = ({ loading, handleRequest }: FieldProp) => {
-  const [address, setAddress] = useState<any>("");
-  const [error, setError] = useState<string>("");
+const EXAMPLE_ADDRESS = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
 
-  const checkAndSendRequest = (address: string) => {
-    setAddress(address)
-    if (!isAddress(address)) {
-      setError("Invalid Address");
-      return;
-    }
-    // Get checksummed format
-    const checksummedAddress = getAddress(address);
-    setAddress(checksummedAddress)
-    handleRequest(checksummedAddress);
-  }
+const Field = ({ loading, handleRequest }: FieldProp) => {
+  const [value, setValue] = useState<string>("");
+  const [error, setError] = useState<string>("");
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
-    checkAndSendRequest(address)
-  };
-
-  const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
-    const newAddress = e.currentTarget.value;
-    checkAndSendRequest(newAddress)
+    if (!isAddress(value)) {
+      setError("Invalid contract address");
+      return;
+    }
+    setError("");
+    handleRequest(getAddress(value));
   };
 
   const handleExample = () => {
-    const exampleAddress = "0x1F98431c8aD98523631AE4a59f267346ea31F984"; // Uniswap
-    checkAndSendRequest(exampleAddress);
+    setValue(EXAMPLE_ADDRESS);
+    setError("");
+    handleRequest(EXAMPLE_ADDRESS);
   };
 
   return (
-    <div className="flex flex-col py-16 px-12 flex-grow rounded-lg transition-all ease-in-out duration-300 bg-white overflow-hidden shadow-md">
-      <div className="flex flex-col text-left relative">
-        {loading && <LoadingOverlay message="Looking up the contract" />}
-        <form onSubmit={handleSubmit}>
-          <label
-            htmlFor="contract-address"
-            className="font-bold mb-8 text-xl block text-center"
-          >
-            Contract Address
-          </label>
-          <Input
+    <div className="relative">
+      {loading && <LoadingOverlay message="Looking up the contract" />}
+      <form onSubmit={handleSubmit}>
+        <div className="flex gap-2">
+          <input
             id="contract-address"
-            value={address}
-            onChange={handleChange}
-            placeholder="0xcaaf6B2ad74003502727e8b8Da046Fab40D6c035"
+            type="text"
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+              if (error) setError("");
+            }}
+            placeholder="0x…"
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-md shadow-sm font-mono text-sm focus:outline-none focus:ring-2 focus:ring-ceruleanBlue-500 focus:border-ceruleanBlue-500"
           />
-          {!!error && (
-            <Toast
-              message={error}
-              isShown={!!error}
-              dismiss={() => setError("")}
-            />
-          )}{" "}
-          <div className="flex justify-end">
-            <button onClick={handleExample} className="text-gray-400">
-              Example Contract
-            </button>
-          </div>
-        </form>
-      </div>
+          <button
+            type="submit"
+            className="inline-flex items-center px-4 py-2 rounded-md text-sm font-medium text-white bg-ceruleanBlue-500 hover:bg-ceruleanBlue-600 focus:outline-none focus:ring-2 focus:ring-ceruleanBlue-500 focus:ring-offset-2 transition-colors"
+          >
+            Look up
+          </button>
+        </div>
+        {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+        <div className="mt-2">
+          <button
+            type="button"
+            onClick={handleExample}
+            className="text-sm text-gray-500 hover:text-ceruleanBlue-500 underline"
+          >
+            Try an example contract
+          </button>
+        </div>
+      </form>
     </div>
   );
 };

--- a/src/pages/Lookup/Field.tsx
+++ b/src/pages/Lookup/Field.tsx
@@ -1,5 +1,5 @@
 import { isAddress, getAddress } from "@ethersproject/address";
-import { FormEventHandler, useState } from "react";
+import { useState } from "react";
 import LoadingOverlay from "../../components/LoadingOverlay";
 
 type FieldProp = {
@@ -11,58 +11,40 @@ const EXAMPLE_ADDRESS = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
 
 const Field = ({ loading, handleRequest }: FieldProp) => {
   const [value, setValue] = useState<string>("");
-  const [error, setError] = useState<string>("");
+  const [touched, setTouched] = useState<boolean>(false);
+  const invalid = touched && value.length > 0 && !isAddress(value);
 
-  const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
-    e.preventDefault();
-    if (!isAddress(value)) {
-      setError("Invalid contract address");
-      return;
+  const handleChange = (input: string) => {
+    setValue(input);
+    if (isAddress(input)) {
+      handleRequest(getAddress(input));
     }
-    setError("");
-    handleRequest(getAddress(value));
-  };
-
-  const handleExample = () => {
-    setValue(EXAMPLE_ADDRESS);
-    setError("");
-    handleRequest(EXAMPLE_ADDRESS);
   };
 
   return (
     <div className="relative">
       {loading && <LoadingOverlay message="Looking up the contract" />}
-      <form onSubmit={handleSubmit}>
-        <div className="flex gap-2">
-          <input
-            id="contract-address"
-            type="text"
-            value={value}
-            onChange={(e) => {
-              setValue(e.target.value);
-              if (error) setError("");
-            }}
-            placeholder="0x…"
-            className="flex-1 px-3 py-2 border border-gray-300 rounded-md shadow-sm font-mono text-sm focus:outline-none focus:ring-2 focus:ring-ceruleanBlue-500 focus:border-ceruleanBlue-500"
-          />
-          <button
-            type="submit"
-            className="inline-flex items-center px-4 py-2 rounded-md text-sm font-medium text-white bg-ceruleanBlue-500 hover:bg-ceruleanBlue-600 focus:outline-none focus:ring-2 focus:ring-ceruleanBlue-500 focus:ring-offset-2 transition-colors"
-          >
-            Look up
-          </button>
-        </div>
-        {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
-        <div className="mt-2">
-          <button
-            type="button"
-            onClick={handleExample}
-            className="text-sm text-gray-500 hover:text-ceruleanBlue-500 underline"
-          >
-            Try an example contract
-          </button>
-        </div>
-      </form>
+      <input
+        id="contract-address"
+        type="text"
+        value={value}
+        onChange={(e) => handleChange(e.target.value)}
+        onBlur={() => setTouched(true)}
+        placeholder="0x…"
+        className={`w-full px-3 py-2 border rounded-md shadow-sm font-mono text-sm focus:outline-none focus:ring-2 focus:ring-ceruleanBlue-500 focus:border-ceruleanBlue-500 ${
+          invalid ? "border-red-400" : "border-gray-300"
+        }`}
+      />
+      {invalid && <p className="text-sm text-red-600 mt-1">Invalid contract address</p>}
+      <div className="mt-2">
+        <button
+          type="button"
+          onClick={() => handleChange(EXAMPLE_ADDRESS)}
+          className="text-sm text-gray-500 hover:text-ceruleanBlue-500 underline"
+        >
+          Try an example contract
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/pages/Lookup/Result.tsx
+++ b/src/pages/Lookup/Result.tsx
@@ -1,239 +1,187 @@
 import { useContext } from "react";
-import { renderToString } from "react-dom/server";
-import { HiBadgeCheck, HiOutlineArrowLeft, HiOutlineInformationCircle, HiX } from "react-icons/hi";
+import { HiOutlineArrowLeft } from "react-icons/hi";
+import { IoOpenOutline } from "react-icons/io5";
 import { Link } from "react-router-dom";
-import { Tooltip } from "react-tooltip";
-import Button from "../../components/Button";
+import MatchBadge from "../../components/MatchBadge";
 import { REPOSITORY_URL } from "../../constants";
 import { Context } from "../../Context";
-import { CheckAllByAddressResult } from "../../types";
-import { isBrowser } from "react-device-detect";
+import { AllChainsResponse, VerifiedContractMinimal } from "../../types";
 
 type ResultProp = {
-  response: CheckAllByAddressResult;
-  goBack: React.DispatchWithoutAction;
-};
-
-const URL_TYPE = {
-  REMIX: "remix",
-  REPO: "repo",
-};
-
-const generateUrl = (type: string, chainId: string, address: string, status: string) => {
-  if (type === URL_TYPE.REMIX)
-    return `https://remix.ethereum.org/?#activate=contract-verification&call=contract-verification//lookupAndSave//sourcify//${chainId}//${address}`;
-  return `${REPOSITORY_URL}/${chainId}/${address}/`;
-};
-
-type NetworkRowProp = {
-  chainId: string;
-  status: string;
-  address: any;
-};
-type FoundProp = {
-  response: CheckAllByAddressResult;
-  goBack: () => void;
-};
-type NotFoundProp = {
-  address: any;
+  address: string;
+  response: AllChainsResponse;
   goBack: () => void;
 };
 
-type MatchStatusProps = {
-  status: string;
+const remixUrl = (chainId: string, address: string) =>
+  `https://remix.ethereum.org/?#activate=contract-verification&call=contract-verification//lookupAndSave//sourcify//${chainId}//${address}`;
+
+const repoUrl = (chainId: string, address: string) => `${REPOSITORY_URL}/${chainId}/${address}/`;
+
+
+
+type ChainRowProps = {
+  contract: VerifiedContractMinimal;
 };
-const PerfectMatchInfoText = (
-  <span>
-    An exact match indicates the Solidity source code does not deviate a single byte from the source code when deployed.{" "}
-    <br /> See{" "}
-    <a href="https://docs.sourcify.dev/docs/exact-match-vs-match" className="underline cursor">
-      docs
-    </a>{" "}
-    for details.
-  </span>
-);
-const PartialMatchInfoText = (
-  <span>
-    A match indicates the Solidity source code functionally corresponds to the deployed contract but some aspects of the
-    source code might differ from the original source code. <br /> See{" "}
-    <a href="https://docs.sourcify.dev/docs/exact-match-vs-match" className="underline cursor">
-      docs
-    </a>{" "}
-    for details.
-  </span>
-);
-const MatchStatusBadge = ({ status }: MatchStatusProps) => {
-  if (status === "perfect") {
-    return (
-      <>
-        <Tooltip delayHide={500} clickable={true} className="max-w-xl" id="perfect-info" />
-        <span
-          className="text-sm px-3 ml-1 py-1.5 capitalize bg-green-600 text-white font-medium rounded-full"
-          data-tooltip-html={renderToString(PerfectMatchInfoText)}
-          data-tooltip-id="perfect-info"
-          data-html={true}
-        >
-          exact match
-        </span>
-      </>
-    );
-  }
-  if (status === "partial") {
-    return (
-      <>
-        <Tooltip delayHide={500} clickable={true} className="max-w-xl" id="partial-info" />
-        <span
-          className="text-sm px-3 ml-1 py-1.5 capitalize bg-partialMatch-500 text-white font-medium rounded-full"
-          data-tooltip-html={renderToString(PartialMatchInfoText)}
-          data-tooltip-id="partial-info"
-          data-html={true}
-        >
-          match
-        </span>
-      </>
-    );
-  }
-  return null;
-};
-const NetworkRow = ({ address, chainId, status }: NetworkRowProp) => {
+
+const ChainRow = ({ contract }: ChainRowProps) => {
   const { sourcifyChainMap } = useContext(Context);
-
-  const chainToName = (chainId: any) => {
-    return sourcifyChainMap[chainId]?.title || sourcifyChainMap[chainId]?.name;
-  };
+  const chain = sourcifyChainMap[parseInt(contract.chainId)];
+  const chainName = chain?.title || chain?.name || `Chain ${contract.chainId}`;
+  const verifiedDate = new Date(contract.verifiedAt).toISOString().split("T")[0];
 
   return (
     <>
-      {isBrowser ? (
-        <tr className="border-b hover:bg-gray-100">
-          <td className="flex items-center py-4  pl-4">
-            <span className="text-lg font-bold">{chainToName(chainId)}</span>{" "}
-          </td>
-          <td>
-            <MatchStatusBadge status={status} />
-          </td>
-          <td className="py-4 text-right">
-            <a className="underline" href={generateUrl(URL_TYPE.REPO, chainId, address, status)}>
-              View in Sourcify Repository
+      {/* Desktop row */}
+      <tr className="hover:bg-gray-50 hidden md:table-row">
+        <td className="px-6 py-4 text-gray-900">
+          <div className="text-base font-medium">{chainName}</div>
+          <div className="text-gray-500 text-xs">Chain ID: {contract.chainId}</div>
+        </td>
+        <td className="px-6 py-4">
+          <MatchBadge match={contract.creationMatch} small />
+        </td>
+        <td className="px-6 py-4">
+          <MatchBadge match={contract.runtimeMatch} small />
+        </td>
+        <td className="px-6 py-4 text-xs text-gray-500 whitespace-nowrap">{verifiedDate}</td>
+        <td className="px-6 py-4">
+          <div className="flex items-center justify-center gap-2 flex-wrap">
+            <a
+              href={repoUrl(contract.chainId, contract.address)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-white bg-ceruleanBlue-500 hover:bg-ceruleanBlue-600 transition-colors whitespace-nowrap"
+            >
+              Sourcify Repo <IoOpenOutline className="w-3.5 h-3.5" />
             </a>
-          </td>
-          <td className="py-4 pr-4 text-right">
-            <a className="underline" href={generateUrl(URL_TYPE.REMIX, chainId, address, status)}>
-              View in Remix
+            <a
+              href={remixUrl(contract.chainId, contract.address)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-ceruleanBlue-600 border border-ceruleanBlue-200 hover:bg-ceruleanBlue-50 transition-colors"
+            >
+              Remix <IoOpenOutline className="w-3.5 h-3.5" />
             </a>
-          </td>
-        </tr>
+          </div>
+        </td>
+        <td className="px-6 py-4 text-xs text-gray-700 font-mono">{contract.matchId}</td>
+      </tr>
+
+      {/* Mobile card */}
+      <tr className="md:hidden">
+        <td colSpan={6} className="px-4 py-4 border-b border-gray-200">
+          <div className="flex items-start justify-between mb-2">
+            <div>
+              <div className="font-medium text-sm text-gray-900">{chainName}</div>
+              <div className="text-gray-500 text-xs">Chain ID: {contract.chainId}</div>
+            </div>
+            <div className="text-xs text-gray-500">{verifiedDate}</div>
+          </div>
+          <div className="flex gap-2 flex-wrap mb-3">
+            <div className="flex items-center gap-1">
+              <span className="text-xs text-gray-500">Creation:</span>
+              <MatchBadge match={contract.creationMatch} small />
+            </div>
+            <div className="flex items-center gap-1">
+              <span className="text-xs text-gray-500">Runtime:</span>
+              <MatchBadge match={contract.runtimeMatch} small />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <a
+              href={repoUrl(contract.chainId, contract.address)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-white bg-ceruleanBlue-500 hover:bg-ceruleanBlue-600 transition-colors whitespace-nowrap"
+            >
+              Sourcify Repo <IoOpenOutline className="w-3.5 h-3.5" />
+            </a>
+            <a
+              href={remixUrl(contract.chainId, contract.address)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-ceruleanBlue-600 border border-ceruleanBlue-200 hover:bg-ceruleanBlue-50 transition-colors"
+            >
+              Remix <IoOpenOutline className="w-3.5 h-3.5" />
+            </a>
+          </div>
+        </td>
+      </tr>
+    </>
+  );
+};
+
+const Result = ({ address, response, goBack }: ResultProp) => {
+  const { results } = response;
+
+  return (
+    <div>
+      {/* Header: back arrow + full address */}
+      <div className="mb-6">
+        <button
+          type="button"
+          onClick={goBack}
+          className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-ceruleanBlue-600 transition-colors mb-3"
+          aria-label="Back to search"
+        >
+          <HiOutlineArrowLeft className="h-4 w-4" /> Back to search
+        </button>
+        <p className="font-mono text-lg md:text-xl font-semibold text-gray-900 break-all">{address}</p>
+      </div>
+
+      {results.length > 0 ? (
+        <div className="overflow-x-auto rounded-lg border border-gray-200 shadow-sm">
+            <table className="w-full border-collapse">
+              <thead>
+                <tr className="bg-gray-100 border-b border-gray-200">
+                  <th className="px-6 py-4 text-left font-semibold text-gray-900">Chain</th>
+                  <th className="px-6 py-4 text-left font-semibold text-gray-900 min-w-[10rem]">Creation Match</th>
+                  <th className="px-6 py-4 text-left font-semibold text-gray-900 min-w-[10rem]">Runtime Match</th>
+                  <th className="px-6 py-4 text-left font-semibold text-gray-900">Verified At</th>
+                  <th className="px-6 py-4 text-center font-semibold text-gray-900 w-px">Source</th>
+                  <th className="px-6 py-4 text-left font-semibold text-gray-900">Match ID</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {results.map((contract) => (
+                  <ChainRow key={`${contract.chainId}-${contract.matchId}`} contract={contract} />
+                ))}
+              </tbody>
+            </table>
+        </div>
       ) : (
-        <div className="border-b hover:bg-gray-100 flex flex-col">
-          <div className="py-4">
-            <span className="text-lg font-bold">{chainToName(chainId)}</span>{" "}
-          </div>
-          <div>
-            <MatchStatusBadge status={status} />
-          </div>
-          <div className="py-4">
-            <a className="underline" href={generateUrl(URL_TYPE.REPO, chainId, address, status)}>
-              View in Sourcify Repository
-            </a>
-          </div>
-          <div className="pb-4">
-            <a className="underline" href={generateUrl(URL_TYPE.REMIX, chainId, address, status)}>
-              View in Remix
-            </a>
-          </div>
+        <div className="bg-gray-50 border border-gray-200 rounded-md p-6 text-center">
+          <p className="text-gray-700 mb-1">
+            The contract at{" "}
+            <span className="font-mono text-sm bg-gray-100 px-1.5 py-0.5 rounded break-all">{address}</span> is not
+            verified on Sourcify.
+          </p>
+          <p className="text-gray-500 text-sm mb-4">Do you have the source code and metadata?</p>
+          <Link
+            to="/verifier"
+            className="inline-flex items-center px-4 py-2 rounded-md text-sm font-medium text-white bg-ceruleanBlue-500 hover:bg-ceruleanBlue-600 focus:outline-none focus:ring-2 focus:ring-ceruleanBlue-500 focus:ring-offset-2 transition-colors"
+          >
+            Verify Contract
+          </Link>
         </div>
       )}
-    </>
-  );
-};
 
-const InfoText = () => (
-  <span>
-    Sourcify verification means a matching Solidity source code of the <br /> contract is available on the Sourcify
-    repo. <br /> See{" "}
-    <a href="https://docs.sourcify.dev/docs/exact-match-vs-match" className="underline cursor">
-      docs
-    </a>{" "}
-    for details.
-  </span>
-);
-
-const Found = ({ response, goBack }: FoundProp) => {
-  const chains = response?.chainIds;
-  return (
-    <div className="flex flex-col justify-center">
-      <Tooltip delayHide={500} clickable={true} className="max-w-xl" id="verified-info" />
-      <div className="sm:mx-20 mt-1 ">
-        <p>
-          The contract at address <span className="font-medium break-all">{response?.address}</span> is{" "}
-          <span data-tooltip-id="verified-info" data-tooltip-html={renderToString(InfoText())}>
-            verified
-            <HiOutlineInformationCircle className="inline text-gray-600 text-lg" />
-          </span>
-        </p>
-        <p>{chains.length > 0 && <span>on the following networks:</span>}</p>
-      </div>
-      {chains.length > 0 ? (
-        <table className="mt-12 mx-4 border-t">
-          {chains.map(({ chainId, status }) => (
-            <NetworkRow address={response?.address} chainId={chainId} status={status} key={chainId} />
-          ))}
-        </table>
-      ) : (
-        <div className="sm:mx-20 mt-1">This contract has not yet been deployed on any chain</div>
-      )}
-      <div className="mt-14">
-        <p>Not verified on the chain you are looking for?</p>
-        <Link to="/verifier">
-          <Button className="mt-4 uppercase">Verify Contract</Button>
-        </Link>
-        <Button type="secondary" className="ml-4 uppercase" onClick={goBack}>
+      {/* CTA row */}
+      <div className="mt-6 flex gap-3 flex-wrap">
+        <button
+          type="button"
+          onClick={goBack}
+          className="inline-flex items-center px-4 py-2 rounded-md text-sm font-medium text-ceruleanBlue-600 border border-ceruleanBlue-200 hover:bg-ceruleanBlue-50 focus:outline-none focus:ring-2 focus:ring-ceruleanBlue-500 focus:ring-offset-2 transition-colors"
+        >
           Lookup Another
-        </Button>
-      </div>
-    </div>
-  );
-};
-
-const NotFound = ({ address, goBack }: NotFoundProp) => {
-  return (
-    <>
-      <div className="sm:mx-20 mt-6">
-        <p>
-          The contract at address <span className="font-medium">{address}</span> is not verified on Sourcify.
-        </p>
-      </div>
-      <div className="mt-14">
-        <p>Do you have the source code and metadata?</p>
-        <Link to="/verifier">
-          <Button className="mt-4 uppercase">Verify Contract</Button>
+        </button>
+        <Link
+          to="/verifier"
+          className="inline-flex items-center px-4 py-2 rounded-md text-sm font-medium text-white bg-ceruleanBlue-500 hover:bg-ceruleanBlue-600 focus:outline-none focus:ring-2 focus:ring-ceruleanBlue-500 focus:ring-offset-2 transition-colors"
+        >
+          Verify Contract
         </Link>
-        <Button type="secondary" className="ml-4 uppercase" onClick={goBack}>
-          Lookup Another
-        </Button>
-      </div>
-    </>
-  );
-};
-
-const verificationIcon = (status: string | undefined) => {
-  if (status === "false") {
-    return <HiX className="text-8xl text-red-600" />;
-  }
-  return <HiBadgeCheck className="text-8xl text-green-600" />;
-};
-
-const Result = ({ response, goBack }: ResultProp) => {
-  return (
-    <div className="flex flex-col basis-0 py-8 flex-grow rounded-lg px-8 transition-all ease-in-out duration-300 bg-white overflow-hidden shadow-md">
-      <HiOutlineArrowLeft className="h-8 w-8 cursor-pointer" onClick={() => goBack()} />
-      <div className="flex flex-col items-center text-center">
-        {verificationIcon(response?.status)}
-        {!!response && response?.status !== "false" ? (
-          <Found response={response} goBack={goBack} />
-        ) : (
-          <NotFound address={response?.address} goBack={goBack} />
-        )}
       </div>
     </div>
   );

--- a/src/pages/Lookup/Result.tsx
+++ b/src/pages/Lookup/Result.tsx
@@ -1,9 +1,8 @@
 import { useContext } from "react";
 import { HiOutlineArrowLeft } from "react-icons/hi";
 import { IoOpenOutline } from "react-icons/io5";
-import { Link } from "react-router-dom";
 import MatchBadge from "../../components/MatchBadge";
-import { REPOSITORY_URL } from "../../constants";
+import { REPOSITORY_URL, VERIFY_URL } from "../../constants";
 import { Context } from "../../Context";
 import { AllChainsResponse, VerifiedContractMinimal } from "../../types";
 
@@ -31,84 +30,40 @@ const ChainRow = ({ contract }: ChainRowProps) => {
   const verifiedDate = new Date(contract.verifiedAt).toISOString().split("T")[0];
 
   return (
-    <>
-      {/* Desktop row */}
-      <tr className="hover:bg-gray-50 hidden md:table-row">
-        <td className="px-6 py-4 text-gray-900">
-          <div className="text-base font-medium">{chainName}</div>
-          <div className="text-gray-500 text-xs">Chain ID: {contract.chainId}</div>
-        </td>
-        <td className="px-6 py-4">
-          <MatchBadge match={contract.creationMatch} small />
-        </td>
-        <td className="px-6 py-4">
-          <MatchBadge match={contract.runtimeMatch} small />
-        </td>
-        <td className="px-6 py-4 text-xs text-gray-500 whitespace-nowrap">{verifiedDate}</td>
-        <td className="px-6 py-4">
-          <div className="flex items-center justify-center gap-2 flex-wrap">
-            <a
-              href={repoUrl(contract.chainId, contract.address)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-white bg-ceruleanBlue-500 hover:bg-ceruleanBlue-600 transition-colors whitespace-nowrap"
-            >
-              Sourcify Repo <IoOpenOutline className="w-3.5 h-3.5" />
-            </a>
-            <a
-              href={remixUrl(contract.chainId, contract.address)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-ceruleanBlue-600 border border-ceruleanBlue-200 hover:bg-ceruleanBlue-50 transition-colors"
-            >
-              Remix <IoOpenOutline className="w-3.5 h-3.5" />
-            </a>
-          </div>
-        </td>
-        <td className="px-6 py-4 text-xs text-gray-700 font-mono">{contract.matchId}</td>
-      </tr>
-
-      {/* Mobile card */}
-      <tr className="md:hidden">
-        <td colSpan={6} className="px-4 py-4 border-b border-gray-200">
-          <div className="flex items-start justify-between mb-2">
-            <div>
-              <div className="font-medium text-sm text-gray-900">{chainName}</div>
-              <div className="text-gray-500 text-xs">Chain ID: {contract.chainId}</div>
-            </div>
-            <div className="text-xs text-gray-500">{verifiedDate}</div>
-          </div>
-          <div className="flex gap-2 flex-wrap mb-3">
-            <div className="flex items-center gap-1">
-              <span className="text-xs text-gray-500">Creation:</span>
-              <MatchBadge match={contract.creationMatch} small />
-            </div>
-            <div className="flex items-center gap-1">
-              <span className="text-xs text-gray-500">Runtime:</span>
-              <MatchBadge match={contract.runtimeMatch} small />
-            </div>
-          </div>
-          <div className="flex gap-2">
-            <a
-              href={repoUrl(contract.chainId, contract.address)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-white bg-ceruleanBlue-500 hover:bg-ceruleanBlue-600 transition-colors whitespace-nowrap"
-            >
-              Sourcify Repo <IoOpenOutline className="w-3.5 h-3.5" />
-            </a>
-            <a
-              href={remixUrl(contract.chainId, contract.address)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-ceruleanBlue-600 border border-ceruleanBlue-200 hover:bg-ceruleanBlue-50 transition-colors"
-            >
-              Remix <IoOpenOutline className="w-3.5 h-3.5" />
-            </a>
-          </div>
-        </td>
-      </tr>
-    </>
+    <tr className="hover:bg-gray-50">
+      <td className="px-6 py-4 text-gray-900">
+        <div className="text-base font-medium">{chainName}</div>
+        <div className="text-gray-500 text-xs">Chain ID: {contract.chainId}</div>
+      </td>
+      <td className="px-6 py-4">
+        <MatchBadge match={contract.creationMatch} small />
+      </td>
+      <td className="px-6 py-4">
+        <MatchBadge match={contract.runtimeMatch} small />
+      </td>
+      <td className="px-6 py-4 text-xs text-gray-500 whitespace-nowrap">{verifiedDate}</td>
+      <td className="px-6 py-4">
+        <div className="flex items-center justify-center gap-2 flex-wrap">
+          <a
+            href={repoUrl(contract.chainId, contract.address)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-white bg-ceruleanBlue-500 hover:bg-ceruleanBlue-600 transition-colors whitespace-nowrap"
+          >
+            Sourcify Repo <IoOpenOutline className="w-3.5 h-3.5" />
+          </a>
+          <a
+            href={remixUrl(contract.chainId, contract.address)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-ceruleanBlue-600 border border-ceruleanBlue-200 hover:bg-ceruleanBlue-50 transition-colors"
+          >
+            Remix <IoOpenOutline className="w-3.5 h-3.5" />
+          </a>
+        </div>
+      </td>
+      <td className="px-6 py-4 text-xs text-gray-700 font-mono">{contract.matchId}</td>
+    </tr>
   );
 };
 
@@ -127,7 +82,7 @@ const Result = ({ address, response, goBack }: ResultProp) => {
         >
           <HiOutlineArrowLeft className="h-4 w-4" /> Back to search
         </button>
-        <p className="font-mono text-lg md:text-xl font-semibold text-gray-900 break-all">{address}</p>
+        <p className="font-mono text-lg md:text-xl font-semibold text-gray-900 break-all text-center">{address}</p>
       </div>
 
       {results.length > 0 ? (
@@ -157,32 +112,18 @@ const Result = ({ address, response, goBack }: ResultProp) => {
             <span className="font-mono text-sm bg-gray-100 px-1.5 py-0.5 rounded break-all">{address}</span> is not
             verified on Sourcify.
           </p>
-          <p className="text-gray-500 text-sm mb-4">Do you have the source code and metadata?</p>
-          <Link
-            to="/verifier"
+          <p className="text-gray-500 text-sm mb-4">Do you have the source code?</p>
+          <a
+            href={VERIFY_URL}
+            target="_blank"
+            rel="noopener noreferrer"
             className="inline-flex items-center px-4 py-2 rounded-md text-sm font-medium text-white bg-ceruleanBlue-500 hover:bg-ceruleanBlue-600 focus:outline-none focus:ring-2 focus:ring-ceruleanBlue-500 focus:ring-offset-2 transition-colors"
           >
             Verify Contract
-          </Link>
+          </a>
         </div>
       )}
 
-      {/* CTA row */}
-      <div className="mt-6 flex gap-3 flex-wrap">
-        <button
-          type="button"
-          onClick={goBack}
-          className="inline-flex items-center px-4 py-2 rounded-md text-sm font-medium text-ceruleanBlue-600 border border-ceruleanBlue-200 hover:bg-ceruleanBlue-50 focus:outline-none focus:ring-2 focus:ring-ceruleanBlue-500 focus:ring-offset-2 transition-colors"
-        >
-          Lookup Another
-        </button>
-        <Link
-          to="/verifier"
-          className="inline-flex items-center px-4 py-2 rounded-md text-sm font-medium text-white bg-ceruleanBlue-500 hover:bg-ceruleanBlue-600 focus:outline-none focus:ring-2 focus:ring-ceruleanBlue-500 focus:ring-offset-2 transition-colors"
-        >
-          Verify Contract
-        </Link>
-      </div>
     </div>
   );
 };

--- a/src/pages/Lookup/Result.tsx
+++ b/src/pages/Lookup/Result.tsx
@@ -43,12 +43,12 @@ const ChainRow = ({ contract }: ChainRowProps) => {
       </td>
       <td className="px-6 py-4 text-xs text-gray-500 whitespace-nowrap">{verifiedDate}</td>
       <td className="px-6 py-4">
-        <div className="flex items-center justify-center gap-2 flex-wrap">
+        <div className="flex flex-col items-stretch gap-2">
           <a
             href={repoUrl(contract.chainId, contract.address)}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-white bg-ceruleanBlue-500 hover:bg-ceruleanBlue-600 transition-colors whitespace-nowrap"
+            className="inline-flex items-center justify-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-white bg-ceruleanBlue-500 hover:bg-ceruleanBlue-600 transition-colors whitespace-nowrap"
           >
             Sourcify Repo <IoOpenOutline className="w-3.5 h-3.5" />
           </a>
@@ -56,13 +56,12 @@ const ChainRow = ({ contract }: ChainRowProps) => {
             href={remixUrl(contract.chainId, contract.address)}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-ceruleanBlue-600 border border-ceruleanBlue-200 hover:bg-ceruleanBlue-50 transition-colors"
+            className="inline-flex items-center justify-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-ceruleanBlue-600 border border-ceruleanBlue-200 hover:bg-ceruleanBlue-50 transition-colors whitespace-nowrap"
           >
             Remix <IoOpenOutline className="w-3.5 h-3.5" />
           </a>
         </div>
       </td>
-      <td className="px-6 py-4 text-xs text-gray-700 font-mono">{contract.matchId}</td>
     </tr>
   );
 };
@@ -95,7 +94,6 @@ const Result = ({ address, response, goBack }: ResultProp) => {
                   <th className="px-6 py-4 text-left font-semibold text-gray-900 min-w-[10rem]">Runtime Match</th>
                   <th className="px-6 py-4 text-left font-semibold text-gray-900">Verified At</th>
                   <th className="px-6 py-4 text-center font-semibold text-gray-900 w-px">Source</th>
-                  <th className="px-6 py-4 text-left font-semibold text-gray-900">Match ID</th>
                 </tr>
               </thead>
               <tbody className="bg-white divide-y divide-gray-200">

--- a/src/pages/Lookup/index.tsx
+++ b/src/pages/Lookup/index.tsx
@@ -1,9 +1,10 @@
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import Header from "../../components/Header";
+import PageLayout from "../../components/PageLayout";
 import Toast from "../../components/Toast";
 import { Context } from "../../Context";
-import { CheckAllByAddressResult } from "../../types";
-import { checkAllByAddresses } from "../../utils/api";
+import { AllChainsResponse } from "../../types";
+import { getVerifiedContractAllChains } from "../../utils/api";
 import Field from "./Field";
 import Result from "./Result";
 import { useParams, useNavigate } from "react-router-dom";
@@ -12,67 +13,62 @@ import { isAddress, getAddress } from "@ethersproject/address";
 const Lookup = () => {
   const navigate = useNavigate();
   const [loading, setLoading] = useState<boolean>(false);
-  const [response, setResponse] = useState<CheckAllByAddressResult | undefined>(undefined);
+  const [response, setResponse] = useState<AllChainsResponse | undefined>(undefined);
+  const [displayAddress, setDisplayAddress] = useState<string | undefined>(undefined);
+  const queriedAddressRef = useRef<string | undefined>(undefined);
   const { address } = useParams();
-  const { sourcifyChains, errorMessage, setErrorMessage } = useContext(Context);
+  const { errorMessage, setErrorMessage } = useContext(Context);
 
-  const handleRequest = async (_address: string) => {
-    if (!sourcifyChains?.length) {
-      return;
-    }
-    setLoading(true);
-    try {
-      const result = await checkAllByAddresses(
-        _address,
-        `0,${sourcifyChains.map((c) => c.chainId.toString()).join(",")}`
-      );
-      const currentAddressMatches = result.find((match) => (match.address = _address));
-      setResponse(currentAddressMatches);
-      navigate(`/address/${_address}`);
-    } catch (err: any) {
-      setErrorMessage(err.message || "An error occurred, try again!");
-      <Toast message={errorMessage} isShown={!!errorMessage} dismiss={() => setErrorMessage("")} />;
-    } finally {
-      setLoading(false);
-    }
-  };
+  const handleRequest = useCallback(
+    async (_address: string) => {
+      queriedAddressRef.current = _address;
+      setLoading(true);
+      try {
+        const result = await getVerifiedContractAllChains(_address);
+        setResponse(result);
+        setDisplayAddress(_address);
+        navigate(`/address/${_address}`);
+      } catch (err: any) {
+        queriedAddressRef.current = undefined;
+        setErrorMessage(err.message || "An error occurred, try again!");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [navigate, setErrorMessage]
+  );
 
   const goBack = () => {
+    queriedAddressRef.current = undefined;
     setResponse(undefined);
-    navigate(`/address`);
+    setDisplayAddress(undefined);
+    navigate("/address");
   };
 
+  // Only depends on the URL param — state changes from goBack cannot re-trigger this.
   useEffect(() => {
-    if (address && address !== response?.address) {
-      if (!isAddress(address)) {
-        return;
-      }
-      // Get checksummed format
-      const checksummedAddress = getAddress(address);
-      handleRequest(checksummedAddress);
+    if (!address) return;
+    if (queriedAddressRef.current === address) return;
+    if (!isAddress(address)) {
+      setErrorMessage("Invalid contract address in URL");
+      return;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sourcifyChains, address]);
+    const checksummedAddress = getAddress(address);
+    queriedAddressRef.current = checksummedAddress;
+    handleRequest(checksummedAddress);
+  }, [address, handleRequest, setErrorMessage]);
 
   return (
-    <div className="flex flex-col flex-1 bg-gray-100">
+    <div className="flex flex-col flex-1">
       <Header />
-      <div className="flex flex-col flex-grow max-w-[100rem] w-full mx-auto pb-8 px-8 md:px-12 lg:px-24 bg-gray-100">
-        <Toast message={errorMessage} isShown={!!errorMessage} dismiss={() => setErrorMessage("")} />
-        <div className="text-center">
-          <h1 className="text-3xl md:text-4xl font-bold">Contract Lookup</h1>
-          <p className="mt-2">Look for verified contracts in the Sourcify repository</p>
-        </div>
-        <div className="flex flex-col flex-grow items-center justify-center mt-6">
-          <div className="pt-1 bg-ceruleanBlue-500 flex h-full w-full  rounded-xl mx-2 mb-4 md:mb-0">
-            {!!response ? (
-              <Result response={response} goBack={goBack} />
-            ) : (
-              <Field loading={loading} handleRequest={handleRequest} />
-            )}
-          </div>
-        </div>
-      </div>
+      <Toast message={errorMessage} isShown={!!errorMessage} dismiss={() => setErrorMessage("")} />
+      <PageLayout title="Contract Lookup" subtitle="Look up verified contracts in the Sourcify repository" maxWidth="max-w-6xl">
+        {response ? (
+          <Result address={displayAddress!} response={response} goBack={goBack} />
+        ) : (
+          <Field loading={loading} handleRequest={handleRequest} />
+        )}
+      </PageLayout>
     </div>
   );
 };

--- a/src/pages/Lookup/index.tsx
+++ b/src/pages/Lookup/index.tsx
@@ -47,7 +47,12 @@ const Lookup = () => {
 
   // Only depends on the URL param — state changes from goBack cannot re-trigger this.
   useEffect(() => {
-    if (!address) return;
+    if (!address) {
+      queriedAddressRef.current = undefined;
+      setResponse(undefined);
+      setDisplayAddress(undefined);
+      return;
+    }
     if (queriedAddressRef.current === address) return;
     if (!isAddress(address)) {
       setErrorMessage("Invalid contract address in URL");
@@ -59,7 +64,7 @@ const Lookup = () => {
   }, [address, handleRequest, setErrorMessage]);
 
   return (
-    <div className="flex flex-col flex-1">
+    <div className="flex flex-col flex-1 overflow-x-hidden">
       <Header />
       <Toast message={errorMessage} isShown={!!errorMessage} dismiss={() => setErrorMessage("")} />
       <PageLayout title="Contract Lookup" subtitle="Look up verified contracts in the Sourcify repository" maxWidth="max-w-6xl">

--- a/src/pages/Lookup/index.tsx
+++ b/src/pages/Lookup/index.tsx
@@ -28,7 +28,7 @@ const Lookup = () => {
       );
       const currentAddressMatches = result.find((match) => (match.address = _address));
       setResponse(currentAddressMatches);
-      navigate(`/lookup/${_address}`);
+      navigate(`/address/${_address}`);
     } catch (err: any) {
       setErrorMessage(err.message || "An error occurred, try again!");
       <Toast message={errorMessage} isShown={!!errorMessage} dismiss={() => setErrorMessage("")} />;

--- a/src/pages/Lookup/index.tsx
+++ b/src/pages/Lookup/index.tsx
@@ -39,7 +39,7 @@ const Lookup = () => {
 
   const goBack = () => {
     setResponse(undefined);
-    navigate(`/lookup`);
+    navigate(`/address`);
   };
 
   useEffect(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,15 +1,20 @@
-export type CheckAllByAddressResult = {
+export interface VerifiedContractMinimal {
+  match: "match" | "exact_match" | null;
+  creationMatch: "match" | "exact_match" | null;
+  runtimeMatch: "match" | "exact_match" | null;
+  chainId: string;
   address: string;
-  status?: string;
-  chainIds: {
-    chainId: string;
-    status: string;
-  }[];
-};
+  verifiedAt: string;
+  matchId: string;
+}
+
+export interface AllChainsResponse {
+  results: VerifiedContractMinimal[];
+}
 
 export type Chain = {
   name: string;
-  title?: string; // Longer name for some networks
+  title?: string;
   chainId: number;
   shortName: string;
   network: string;

--- a/src/utils/api.tsx
+++ b/src/utils/api.tsx
@@ -1,48 +1,13 @@
 import { SERVER_URL, BIGQUERY_API_URL } from "../constants";
-import { Chain, CheckAllByAddressResult } from "../types";
+import { AllChainsResponse, Chain } from "../types";
 
-type ChainIdsResponse = {
-  chainId: string;
-  status: string;
+export const getVerifiedContractAllChains = async (address: string): Promise<AllChainsResponse> => {
+  const response = await fetch(`${SERVER_URL}/v2/contract/all-chains/${address}`);
+  if (response.status === 404) return { results: [] };
+  if (!response.ok) throw new Error(`Lookup failed: ${response.status} ${response.statusText}`);
+  return response.json();
 };
 
-export type ServersideAddressCheck = {
-  address: string;
-  status: string;
-  chainIds?: ChainIdsResponse[];
-};
-
-export const checkAllByAddresses = async (
-  addresses: string,
-  chainIds: string
-): Promise<CheckAllByAddressResult[]> => {
-  const response = await fetch(
-    `${SERVER_URL}/checkAllByAddresses?addresses=${addresses}&chainIds=${chainIds}`,
-    {
-      method: "GET",
-    }
-  );
-
-  if (!response.ok) {
-    // e.g. HTTP 400 invalid address
-    let jsonError;
-    try {
-      jsonError = await response.json();
-    } catch (e) {
-      throw new Error("Cannot parse the error message");
-    }
-    throw new Error(jsonError.message);
-  }
-
-  return await response.json();
-};
-
-/**
- * @function to fetch Sourcify's chains array and return as an object with the chainId as keys.
- *
- * The Ethereum networks are placed on top, the rest of the networks are sorted alphabetically.
- *
- */
 export const getSourcifyChains = async (): Promise<Chain[]> => {
   const chainsArray = await (await fetch(`${SERVER_URL}/chains`)).json();
   return chainsArray;
@@ -62,9 +27,7 @@ export interface BigQueryResponse {
   rows: any[];
 }
 
-export const bigquery = async (
-  sql: string
-): Promise<BigQueryResponse> => {
+export const bigquery = async (sql: string): Promise<BigQueryResponse> => {
   const response = await fetch(`${BIGQUERY_API_URL}`, {
     method: "POST",
     headers: {
@@ -74,7 +37,6 @@ export const bigquery = async (
   });
 
   if (!response.ok) {
-    // e.g. HTTP 400 invalid address
     let jsonError;
     try {
       jsonError = await response.json();

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,7 @@ module.exports = {
     extend: {
       colors: {
         ceruleanBlue: {
+          50: "#f3f6ff",
           100: "#E8EFFF",
           200: "#A9BDEE",
           300: "#7693DA",


### PR DESCRIPTION
Closes https://github.com/argotorg/sourcify/issues/2679

## Summary

- Replaces hash routing (`/#/lookup/0x...`) with clean URL routing (`/address/:address`), preserving all legacy links via a pre-React hash-rewrite shim in `index.html` and client-side redirects for `/lookup/*` routes.
- Redesigns the `/address` page to match `verify.sourcify.dev`'s visual style: stacked cerulean card, IBM Plex typography, MatchBadge pills, bordered table.
- Migrates the data layer from Sourcify v1 (`checkAllByAddresses`) to v2 (`GET /v2/contract/all-chains/{address}`), surfacing `creationMatch`, `runtimeMatch`, `verifiedAt`, and `matchId` per chain.
- Auto-searches as soon as a valid address is typed; shows inline error on blur for invalid input.
- Fixes several pre-existing bugs: double-fetch on keypress, `react-device-detect` UA sniffing, missing `<tbody>`, `match.address = _address` assignment bug, back-to-search race condition.

## Question for reviewers

**What do you think about using `/address/` as the route for contract lookup?**

The original route was `/lookup/:address`. The new route is `/address/:address` (with `/address` as the landing page). The reasoning: it's shorter, more semantic, and aligns with how block explorers reference contracts. Legacy `/lookup/*` links are redirected automatically. Open to other suggestions if you'd prefer something different (e.g. `/contract/`, `/lookup/` kept as-is, etc.).

## Test plan

- [ ] **Legacy hash redirect** — visit `/#/lookup/0x1F98431c8aD98523631AE4a59f267346ea31F984`. Confirm it rewrites to `/address/0x1F98431c8aD98523631AE4a59f267346ea31F984` and renders the result.
- [ ] **Other legacy hash routes** — visit `/#/` and `/#/anything`. Confirm they rewrite to `/` and `/anything` respectively (no hash).
- [ ] **Empty state** — visit `/address`. Confirm: stacked-card layout with cerulean offset rectangle, title "Contract Lookup", input field with cerulean focus ring, "Try an example contract" link.
- [ ] **Auto-search** — paste `0x1F98431c8aD98523631AE4a59f267346ea31F984` into the input. Confirm search fires immediately without pressing any button.
- [ ] **Valid address with matches** — confirm Network tab shows a single `GET /v2/contract/all-chains/0x1F98431c...`. UI: results table with one row per chain, Creation Match + Runtime Match badges, ISO verified date, Sourcify Repo + Remix links work.
- [ ] **Unverified address** — paste a known-unverified address. Confirm: UI shows "Not verified on Sourcify" panel with Verify CTA linking to `verify.sourcify.dev` (or staging equivalent).
- [ ] **Invalid input** — type `0xnotanaddress` then click away. Confirm: red border + inline error, no API request fired.
- [ ] **Direct deep-link** — visit `/address/0x1F98431c8aD98523631AE4a59f267346ea31F984`. Confirm: result page renders directly (no flash of empty state).
- [ ] **Invalid `:address` param** — visit `/address/garbage`. Confirm: error toast (was silent before).
- [ ] **Back to search / header Lookup link** — on a result page, click "Back to search" or the Lookup nav link. Confirm it navigates to `/address` and stays there (was re-navigating back to the result due to a race condition).
- [ ] **Responsive** — resize the browser narrow. Confirm: table scrolls horizontally within the card; page itself does not scroll horizontally.
- [ ] **Sourcify Repo link** — on staging, confirm the Sourcify Repo button links to `repo.staging.sourcify.dev`; on production `repo.sourcify.dev`.
- [ ] **Tooltips** — hover a MatchBadge. Confirm the tooltip appears above the card (was hidden behind it before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)