### PR TITLE
Use absolute asset paths to fix /#/lookup legacy redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,5 +72,5 @@
     "react-scripts": "5.0.1",
     "tailwindcss": "3.4.19"
   },
-  "homepage": "./"
+  "homepage": "/"
 }


### PR DESCRIPTION
## Summary

Fixes the broken legacy hash redirect on staging: `https://staging.sourcify.dev/#/lookup/0x1F98...` returns a blank page because asset URLs 404.

## Root cause

`package.json` had `"homepage": "./"`, which makes Create React App emit **relative** asset paths in `index.html`:

```html
<script src="./static/js/main.06be735a.js"></script>
```

The flow that breaks:

1. Browser visits `/#/lookup/0x1F98...` → `GET /` → server returns `index.html` ✓
2. The inline shim runs `history.replaceState(null, "", "/address/0x1F98...")` ✓
3. Browser continues parsing HTML and hits `<script src="./static/js/main.xxx.js">`
4. Relative URL resolves against the **new** document URL → tries to load `https://staging.sourcify.dev/address/static/js/main.xxx.js` → **404**
5. No JS loads → blank page

This worked under HashRouter because the path was always `/`, so `./static/...` always resolved to `/static/...`.

## Fix

Change `homepage` from `"./"` to `"/"`. Built `index.html` now emits absolute paths:

```html
<script src="/static/js/main.xxx.js"></script>
```

These resolve to `/static/js/...` regardless of the document URL after `replaceState`.

## Required server-side companion change (out of scope for this PR)

For direct visits to clean URLs like `staging.sourcify.dev/address/0x...`, the GCP backend bucket needs SPA fallback configured (this is a separate problem, not fixed by this PR):

```bash
gcloud compute backend-buckets update sourcify-staging-ui \
  --custom-error-response-policy="error-response-rule=match_response_codes=404,path=/index.html,override_response_code=200"
```

## Test plan

- [ ] Local: `npm run build && grep 'src="' build/index.html` — confirm `/static/...` (absolute), not `./static/...`.
- [ ] After deploy to staging: visit `https://staging.sourcify.dev/#/lookup/0x1F98431c8aD98523631AE4a59f267346ea31F984`. Confirm: page loads, URL becomes `/address/0x1F98...`, lookup result renders.
- [ ] Confirm `https://staging.sourcify.dev/` still loads (regression check).
- [ ] After GCP backend bucket SPA fallback is configured: confirm direct visit to `https://staging.sourcify.dev/address/0x1F98...` loads (not blocked by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)