### PR TITLE
Add staging/dev environment banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useParams } from "react-router-dom";
 import { Tooltip } from "react-tooltip";
 import { ContextProvider } from "./Context";
+import StagingBanner from "./components/StagingBanner";
 import LandingPage from "./pages/LandingPage";
 import Lookup from "./pages/Lookup";
 import VerifyRedirect from "./pages/VerifyRedirect";
@@ -19,22 +20,25 @@ function App() {
   }, []);
 
   return (
-    <div className="flex min-h-screen text-gray-800 bg-gray-50">
-      <Tooltip id="global-tooltip" delayHide={300} clickable style={{ zIndex: 9999, maxWidth: "16rem", fontSize: "0.75rem" }} />
-      <ContextProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/verifier" element={<VerifyRedirect />} />
-            <Route path="/lookup" element={<LegacyLookupRedirect />} />
-            <Route path="/lookup/:address" element={<LegacyLookupRedirect />} />
-            <Route path="/address" element={<Lookup />} />
-            <Route path="/address/:address" element={<Lookup />} />
-            <Route path="/dataset-playground" element={<LandingPage />} />
-            <Route path="/" element={<LandingPage />} />
-          </Routes>
-        </BrowserRouter>
-      </ContextProvider>
-    </div>
+    <>
+      <StagingBanner />
+      <div className="flex min-h-screen text-gray-800 bg-gray-50">
+        <Tooltip id="global-tooltip" delayHide={300} clickable style={{ zIndex: 9999, maxWidth: "16rem", fontSize: "0.75rem" }} />
+        <ContextProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/verifier" element={<VerifyRedirect />} />
+              <Route path="/lookup" element={<LegacyLookupRedirect />} />
+              <Route path="/lookup/:address" element={<LegacyLookupRedirect />} />
+              <Route path="/address" element={<Lookup />} />
+              <Route path="/address/:address" element={<Lookup />} />
+              <Route path="/dataset-playground" element={<LandingPage />} />
+              <Route path="/" element={<LandingPage />} />
+            </Routes>
+          </BrowserRouter>
+        </ContextProvider>
+      </div>
+    </>
   );
 }
 

--- a/src/components/StagingBanner/index.tsx
+++ b/src/components/StagingBanner/index.tsx
@@ -1,0 +1,19 @@
+// Shown only on non-production (staging/dev) deployments. Production builds
+// set REACT_APP_TAG to "master"; anything else is treated as staging.
+const isStaging = process.env.REACT_APP_TAG !== "master";
+
+const StagingBanner = () => {
+  if (!isStaging) {
+    return null;
+  }
+
+  return (
+    <div className="w-full bg-ceruleanBlue-500 text-white text-center font-medium py-3 px-4">
+      🚧 You are on the <span className="font-bold">staging/dev</span> environment{" "}
+      <span className="mx-1 text-xl align-middle">—</span>{" "}
+      <span className="font-mono font-normal">{window.location.href}</span>
+    </div>
+  );
+};
+
+export default StagingBanner;


### PR DESCRIPTION
Adds a consistent banner shown only on non-production (staging/dev) deployments.

## What
- New `StagingBanner` component rendered at the top of the app.
- Full-width bar in the sourcify blue (`ceruleanBlue-500`), white centered text:
  > 🚧 You are on the **staging/dev** environment — `<current URL>`
- Hidden on production builds.

## Detection
Uses `process.env.REACT_APP_TAG !== "master"`. Production builds use `.env.build.main` (`REACT_APP_TAG=master`); staging uses `.env.build.staging`. This mirrors the existing `(staging)` document-title logic in `App.tsx`.

Part of a set of matching banners across sourcify-ui, verify.sourcify.dev, and repo.sourcify.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)