### PR TITLE
Pick free OpenRouter models dynamically in AI playground

### DIFF
--- a/src/components/BigQueryExplorer/AIGenerator.tsx
+++ b/src/components/BigQueryExplorer/AIGenerator.tsx
@@ -4,6 +4,22 @@ import { FiExternalLink } from "react-icons/fi";
 import Button from "../Button";
 import { OPENROUTER_API_KEY } from "../../constants";
 
+// The stable auto-router; always a valid free option regardless of rotation.
+export const FREE_ROUTER_MODEL = "openrouter/free";
+
+type FreeModel = { id: string; name: string };
+
+// A model is usable on the built-in app key only if it's actually free.
+export const isFreeModel = (id: string, freeModels: FreeModel[]): boolean => {
+  const trimmed = id.trim();
+  return (
+    trimmed === FREE_ROUTER_MODEL ||
+    freeModels.some((m) => m.id === trimmed) ||
+    // Fallback when the live list couldn't be fetched.
+    trimmed.endsWith(":free")
+  );
+};
+
 type Props = {
   nlPrompt: string;
   setNlPrompt: (v: string) => void;
@@ -29,10 +45,57 @@ const AIGenerator = ({
 }: Props) => {
   const [validatingModel, setValidatingModel] = useState(false);
   const [modelValid, setModelValid] = useState<boolean | null>(null);
+  const [freeModels, setFreeModels] = useState<FreeModel[]>([]);
+  const [modelsLoading, setModelsLoading] = useState(true);
+  const [customModel, setCustomModel] = useState(false);
 
   const usingBuiltInAppKey = useMemo(() => {
     return !apiKey && !!OPENROUTER_API_KEY;
   }, [apiKey]);
+
+  // Fetch the current list of free models from OpenRouter on mount. This is a
+  // public endpoint (no key required) so the dropdown always reflects what's
+  // actually available, instead of a hardcoded slug that goes stale.
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const res = await fetch("https://openrouter.ai/api/v1/models");
+        if (!res.ok) throw new Error(`status ${res.status}`);
+        const json = await res.json();
+        const list: any[] = Array.isArray(json?.data) ? json.data : [];
+        const free = list
+          .filter(
+            (m) =>
+              m?.pricing &&
+              Number(m.pricing.prompt) === 0 &&
+              Number(m.pricing.completion) === 0 &&
+              // Only text-output models are useful for SQL generation.
+              (m?.architecture?.output_modalities?.includes("text") ?? true) &&
+              m.id !== FREE_ROUTER_MODEL
+          )
+          .map((m) => ({ id: m.id as string, name: (m.name as string) || m.id }))
+          .sort((a, b) => a.name.localeCompare(b.name));
+        if (active) setFreeModels(free);
+      } catch {
+        // Leave the list empty; the stable router default still works and the
+        // ":free" fallback in isFreeModel keeps custom entries usable.
+      } finally {
+        if (active) setModelsLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // If the current model isn't a known dropdown option, treat it as custom.
+  useEffect(() => {
+    const trimmed = model?.trim();
+    if (!trimmed) return;
+    const known = trimmed === FREE_ROUTER_MODEL || freeModels.some((m) => m.id === trimmed);
+    if (!known) setCustomModel(true);
+  }, [model, freeModels]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
@@ -51,12 +114,17 @@ const AIGenerator = ({
       return;
     }
     const trimmed = model.trim();
-    // If using the app key (built-in), only allow :free models
+    // The stable router and any model from the fetched free list are known-good;
+    // skip the network round-trip for them.
+    if (trimmed === FREE_ROUTER_MODEL || freeModels.some((m) => m.id === trimmed)) {
+      setValidatingModel(false);
+      setModelValid(true);
+      return;
+    }
+    // If using the app key (built-in), only free models are allowed.
     if (usingBuiltInAppKey) {
-      if (!trimmed.endsWith(":free")) {
-        setModelValid(false);
-        return;
-      }
+      setModelValid(isFreeModel(trimmed, freeModels));
+      return;
     }
     setValidatingModel(true);
     const slug = trimmed.split(":")[0];
@@ -92,7 +160,7 @@ const AIGenerator = ({
       clearTimeout(timer);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apiKey, model, usingBuiltInAppKey]);
+  }, [apiKey, model, usingBuiltInAppKey, freeModels]);
 
   return (
     <form onSubmit={onGenerate} className="bg-white rounded-xl shadow overflow-hidden mb-6">
@@ -128,34 +196,66 @@ const AIGenerator = ({
         />
 
         <div className="mt-3 flex flex-col md:flex-row gap-2 md:gap-3 items-start">
-          <div className="flex items-center gap-1 flex-1">
-            <label className="text-sm text-gray-600">Model</label>
-            <a
-              href="https://openrouter.ai/models?order=newest&q=%3Afree"
-              target="_blank"
-              rel="noopener noreferrer"
-              title="Find more free models"
-              aria-label="Find more free models"
-              className="text-gray-400 hover:text-ceruleanBlue-600 transition-colors"
-            >
-              <FiExternalLink className="h-4 w-4" aria-hidden="true" />
-            </a>
-            <div className="w-full">
+          <div className="flex flex-col gap-1 flex-1 w-full">
+            <div className="flex items-center gap-1">
+              <label className="text-sm text-gray-600">Model</label>
+              <a
+                href="https://openrouter.ai/models?order=newest&q=%3Afree"
+                target="_blank"
+                rel="noopener noreferrer"
+                title="Browse all free models on OpenRouter"
+                aria-label="Browse all free models on OpenRouter"
+                className="text-gray-400 hover:text-ceruleanBlue-600 transition-colors"
+              >
+                <FiExternalLink className="h-4 w-4" aria-hidden="true" />
+              </a>
+              {modelsLoading && (
+                <svg className="animate-spin h-3.5 w-3.5 text-gray-400" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+                </svg>
+              )}
+            </div>
+            <div className="flex items-center gap-2 w-full">
+              <select
+                value={customModel ? "__custom__" : model}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (v === "__custom__") {
+                    setCustomModel(true);
+                    setModel("");
+                  } else {
+                    setCustomModel(false);
+                    setModel(v);
+                  }
+                }}
+                className="border border-gray-200 rounded-md px-2 py-2 text-sm w-full bg-white"
+              >
+                <option value={FREE_ROUTER_MODEL}>Auto — random free model (recommended)</option>
+                {freeModels.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.name}
+                  </option>
+                ))}
+                {!usingBuiltInAppKey && <option value="__custom__">Custom model ID…</option>}
+              </select>
+              {validatingModel && (
+                <svg className="animate-spin h-4 w-4 text-gray-500 shrink-0" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+                </svg>
+              )}
+              {modelValid === true && !validatingModel && <span className="text-green-600 text-xs shrink-0">Valid</span>}
+              {modelValid === false && !validatingModel && <span className="text-red-600 text-xs shrink-0">Invalid</span>}
+            </div>
+            {customModel && (
               <input
                 value={model}
                 onChange={(e) => setModel(e.target.value)}
-                placeholder="author/slug:free (e.g., meta-llama/llama-3.1-8b-instruct:free)"
+                placeholder="author/slug (any model, requires your key)"
                 className="border border-gray-200 rounded-md px-2 py-2 text-sm w-full"
               />
-            </div>
-            {validatingModel && (
-              <svg className="animate-spin h-4 w-4 text-gray-500" viewBox="0 0 24 24" fill="none">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
-              </svg>
             )}
-            {modelValid === true && !validatingModel && <span className="text-green-600 text-xs">Valid</span>}
-            {modelValid === false && !validatingModel && <span className="text-red-600 text-xs">Invalid</span>}
           </div>
 
           <div className="flex-1 flex flex-col gap-1 items-start md:items-end justify-center">
@@ -173,8 +273,8 @@ const AIGenerator = ({
             <div>
               <div className="text-xs text-gray-500">
                 {apiKey
-                  ? "Using your OpenRouter key, all models supported"
-                  : "No key provided, only ':free' models supported"}
+                  ? "Using your OpenRouter key — any model supported"
+                  : "No key — free models only. Add a key to use any model."}
               </div>
             </div>
           </div>

--- a/src/components/BigQueryExplorer/constants.ts
+++ b/src/components/BigQueryExplorer/constants.ts
@@ -99,4 +99,7 @@ Foreign keys:
 export const DEFAULT_PROMPT =
   "Which contract is the most popular contract by contract name?";
 
-export const DEFAULT_MODEL = "arcee-ai/trinity-large-preview:free";
+// Stable OpenRouter meta-model that auto-routes to whatever free models are
+// currently available, so this default never goes stale as free models rotate.
+// See: https://openrouter.ai/openrouter/free
+export const DEFAULT_MODEL = "openrouter/free";

--- a/src/components/BigQueryExplorer/index.tsx
+++ b/src/components/BigQueryExplorer/index.tsx
@@ -3,7 +3,7 @@ import { bigquery, BigQueryResponse } from "../../utils/api";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { generateText } from "ai";
 import { DEFAULT_SQL, SYSTEM_PROMPT, DEFAULT_PROMPT, DEFAULT_MODEL } from "./constants";
-import AIGenerator from "./AIGenerator";
+import AIGenerator, { FREE_ROUTER_MODEL } from "./AIGenerator";
 import SqlEditor from "./SqlEditor";
 import Results from "./Results";
 import { OPENROUTER_API_KEY } from "../../constants";
@@ -78,8 +78,10 @@ const BigQueryExplorer = () => {
       const chosenModel = model;
       // Runtime enforcement for built-in key
       const usingAppKey = !apiKey && OPENROUTER_API_KEY;
-      if (usingAppKey && !chosenModel.trim().endsWith(":free")) {
-        throw new Error("Only :free models are supported with the built-in key");
+      const trimmedModel = chosenModel.trim();
+      const isFree = trimmedModel === FREE_ROUTER_MODEL || trimmedModel.endsWith(":free");
+      if (usingAppKey && !isFree) {
+        throw new Error("Only free models are supported with the built-in key");
       }
       const system = SYSTEM_PROMPT;
       const prompt = `User request: ${nlPrompt}\n Return only the SQL statement that fulfills it.`;


### PR DESCRIPTION
## Problem

The AI query generator in the Dataset Playground prefilled a hardcoded `:free` model slug (`arcee-ai/trinity-large-preview:free`). OpenRouter's free models rotate frequently, so this constantly goes stale — the previous default was **already dead**, meaning the playground shipped with a broken model out of the box.

## Changes

- **Default is now `openrouter/free`** — OpenRouter's stable "Free Models Router" that auto-routes to a currently-available free model. This default never goes stale.
- **Live model dropdown** — populated on page load from OpenRouter's public `/api/v1/models` endpoint (no key required), filtered to free text-output models. Users can pick a specific free model that's actually available right now, instead of typing an exact slug.
- **Custom model option** — when the user provides their own OpenRouter key, a "Custom model ID…" option reveals a text field for any model.
- **Guard fix** — the built-in-key check required a `:free` suffix, which would have rejected `openrouter/free`. It now accepts the router ID as well.

If the models fetch fails, the dropdown still offers the stable "Auto" default, so the playground is never left broken regardless of model rotation.

## Trade-off

`openrouter/free` routes *randomly* among free models, so SQL-generation quality varies run to run. Users who want consistency can pick a specific coder model (e.g. `qwen/qwen3-coder:free`) from the dropdown — which is why both the router default and the curated list are offered.

## Verification

- `tsc --noEmit` clean, `eslint` clean on changed files.
- Ran the dev build locally; playground compiles and renders the new dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)